### PR TITLE
[docs] Bootstrap in-repo developer wiki with comprehensive documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Renaissance
+
+A React Native / Expo mobile app for the Renaissance community platform.
+
+## Documentation
+
+See the [Developer Wiki](./wiki/README.md) for comprehensive documentation including setup guides, architecture details, and contribution guidelines.

--- a/wiki/AGENTS.md
+++ b/wiki/AGENTS.md
@@ -1,0 +1,212 @@
+# AGENTS.md
+
+Instructions and context for AI agents working on the Renaissance codebase.
+
+## Project Context
+
+**Renaissance** is a React Native / Expo mobile application for event discovery and community engagement. The app aggregates events from multiple sources (Luma, Resident Advisor, Meetup, Instagram) and provides social features, Web3 wallet integration, and a rewards system.
+
+### Key Technical Details
+
+- **Framework**: React Native 0.81.5 + Expo SDK 54
+- **Language**: TypeScript 5.9.x (strict mode)
+- **State Management**: React Context API (no Redux)
+- **Navigation**: React Navigation 6.x (Stack Navigator)
+- **Package Manager**: Yarn (Classic)
+- **Node Version**: >= 20.19.0
+
+## Repository Structure Summary
+
+```
+renaissance/
+├── App.tsx              # Entry point with providers
+├── src/
+│   ├── api/             # API client modules
+│   ├── Components/      # Reusable UI components
+│   ├── Screens/         # Screen components (views)
+│   ├── Navigation/      # React Navigation config
+│   ├── context/         # React Context providers
+│   ├── hooks/           # Custom React hooks
+│   ├── utils/           # Utility functions
+│   ├── config/          # App configuration
+│   ├── interfaces/      # TypeScript interfaces
+│   ├── dpop.ts          # Main API client
+│   ├── colors.ts        # Theme definitions
+│   └── interfaces.ts    # Core type definitions
+├── wiki/                # Developer documentation
+├── app.json             # Expo configuration
+├── eas.json             # EAS Build profiles
+└── package.json         # Dependencies
+```
+
+## Important Files to Understand
+
+| File | Purpose |
+|------|---------|
+| `App.tsx` | App entry, provider hierarchy, deep linking |
+| `src/dpop.ts` | Primary API client (auth, events, content) |
+| `src/interfaces.ts` | Core TypeScript interfaces |
+| `src/colors.ts` | Theme system (dark/light themes) |
+| `src/Navigation/HomeNavigationStack.tsx` | All screen routes |
+| `src/context/Auth.tsx` | Authentication state |
+| `src/context/LocalStorage.tsx` | AsyncStorage wrapper |
+
+## Coding Conventions
+
+### General
+
+- Use TypeScript with explicit types
+- Functional components with hooks
+- StyleSheet for styling (not inline styles)
+- Theme colors from `src/colors.ts`
+
+### Naming
+
+- **Components**: PascalCase (`EventCard.tsx`)
+- **Hooks**: camelCase with `use` prefix (`useEvents.ts`)
+- **Utils**: camelCase (`formatDate.ts`)
+- **Interfaces**: PascalCase with descriptive names (`DAEvent`, `LumaEvent`)
+
+### Component Pattern
+
+```typescript
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { theme } from '../colors';
+
+interface Props {
+  title: string;
+  onPress?: () => void;
+}
+
+export const MyComponent: React.FC<Props> = ({ title, onPress }) => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{title}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: theme.surface,
+    padding: 16,
+  },
+  title: {
+    color: theme.text,
+    fontSize: 16,
+  },
+});
+```
+
+### Hook Pattern
+
+```typescript
+import { useState, useEffect } from 'react';
+
+export const useMyData = () => {
+  const [data, setData] = useState<DataType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    fetchData()
+      .then(setData)
+      .catch(setError)
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { data, loading, error };
+};
+```
+
+## Common Tasks
+
+### Adding a New Screen
+
+1. Create screen file in `src/Screens/`
+2. Add route in `src/Navigation/HomeNavigationStack.tsx`
+3. Add type to `HomeNavigationStackParamList`
+
+### Adding a New API Endpoint
+
+1. Add function in `src/dpop.ts` or relevant `src/api/` module
+2. Create hook in `src/hooks/` if needed
+3. Add TypeScript interfaces
+
+### Adding a Component
+
+1. Create file in `src/Components/`
+2. Follow component pattern above
+3. Export from component file
+
+### Modifying Theme
+
+1. Edit `src/colors.ts`
+2. Add to both `darkTheme` and `lightTheme`
+3. Use semantic token names
+
+## API Information
+
+### Backend Services
+
+- **Main API**: `https://api.detroiter.network`
+- **Events API**: `https://events.builddetroit.xyz`
+- **Storage**: `https://dpop.nyc3.digitaloceanspaces.com`
+
+### Authentication
+
+The app uses DPoP (Decentralized Proof of Participation) tokens stored in AsyncStorage:
+- `DPoPToken` – JWT bearer token
+- `DPoPUser` – User object
+- `DPoPContact` – Contact/profile data
+
+## Things to Avoid
+
+- **Don't use Redux** – Use React Context instead
+- **Don't add inline styles** – Use StyleSheet
+- **Don't hardcode colors** – Use theme tokens
+- **Don't create .md files** unless explicitly requested
+- **Don't modify package.json** unless asked
+- **Don't run `eas build` or `eas update`** unless asked
+- **Don't git commit/push** unless asked
+
+## Testing Changes
+
+```bash
+# Start dev server
+yarn start
+
+# Type check
+npx tsc --noEmit
+
+# Run on iOS
+yarn ios
+
+# Run on Android
+yarn android
+```
+
+## Useful Commands
+
+```bash
+# Clear cache
+npx expo start --clear
+
+# Check for TS errors
+npx tsc --noEmit
+
+# Install dependencies
+yarn install
+```
+
+## Documentation Reference
+
+For detailed information, refer to the wiki:
+- [Project Overview](./project-overview.md)
+- [Repository Structure](./repo-structure.md)
+- [Architecture](./architecture.md)
+- [Local Dev Setup](./local-dev-setup.md)
+- [Environment Config](./environment-config.md)
+- [Tools & Dependencies](./tools.md)
+- [Contributing](./contributing.md)

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,41 @@
+# Renaissance App Developer Wiki
+
+Welcome to the developer wiki for the **Renaissance** mobile application. This documentation covers everything you need to contribute to and understand the codebase.
+
+## Quick Links
+
+| Document | Description |
+|----------|-------------|
+| [Project Overview](./project-overview.md) | What Renaissance is, who it's for, and high-level goals |
+| [Repository Structure](./repo-structure.md) | Annotated tour of the codebase layout |
+| [Local Development Setup](./local-dev-setup.md) | Get the app running on your machine |
+| [Architecture](./architecture.md) | Technical architecture and design decisions |
+| [Features](./features.md) | Overview of app features and capabilities |
+| [Environment & Config](./environment-config.md) | Environment variables and build configuration |
+| [Tools & Dependencies](./tools.md) | Key libraries and tools used in the project |
+| [Contributing](./contributing.md) | Contribution guidelines, PR process, code style |
+| [AGENTS](./AGENTS.md) | Instructions for AI agents working on this codebase |
+
+## Getting Started
+
+If you're new to the project, we recommend reading the documentation in this order:
+
+1. **[Project Overview](./project-overview.md)** – Understand what we're building
+2. **[Local Development Setup](./local-dev-setup.md)** – Get your environment running
+3. **[Repository Structure](./repo-structure.md)** – Navigate the codebase
+4. **[Architecture](./architecture.md)** – Understand how the pieces fit together
+5. **[Contributing](./contributing.md)** – Learn how to submit changes
+
+## About This Wiki
+
+This wiki is maintained in-repo under the `wiki/` directory. All documentation is written in Markdown and renders cleanly on GitHub. If you find outdated or missing information, please submit a PR to update the relevant documentation.
+
+### Related Repositories
+
+- [`renaissance-contracts`](https://github.com/buidl-renaissance/renaissance-contracts) – Smart contracts for Renaissance
+- [`dpop`](https://github.com/buidl-renaissance/dpop) – DPoP authentication protocol
+- [`regen-art`](https://github.com/buidl-renaissance/regen-art) – Generative art components
+
+---
+
+*Last updated: May 2026*

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -1,0 +1,269 @@
+# Architecture
+
+This document describes the high-level architecture of the Renaissance mobile application.
+
+## Technology Stack
+
+| Layer | Technology |
+|-------|------------|
+| **Framework** | React Native 0.81.5 |
+| **Platform** | Expo SDK 54 |
+| **Language** | TypeScript 5.9.x |
+| **Navigation** | React Navigation 6.x (Stack + Bottom Tabs) |
+| **State** | React Context API |
+| **Storage** | AsyncStorage (via `@react-native-async-storage/async-storage`) |
+| **Web3** | ethers.js 5.x, CosmJS 0.33.x |
+| **Styling** | React Native StyleSheet + Theme system |
+
+## Application Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        App.tsx                               │
+│  (Entry point, providers, navigation container)              │
+├─────────────────────────────────────────────────────────────┤
+│                    Context Providers                         │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐       │
+│  │  Local   │ │  Tenant  │ │   Auth   │ │ Farcaster│       │
+│  │ Storage  │ │ Context  │ │ Provider │ │  Frame   │       │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘       │
+│  ┌──────────┐ ┌──────────┐                                  │
+│  │  Audio   │ │   Web3   │                                  │
+│  │  Player  │ │ Context  │                                  │
+│  └──────────┘ └──────────┘                                  │
+├─────────────────────────────────────────────────────────────┤
+│                  Navigation (React Navigation)               │
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │              HomeNavigationStack                        ││
+│  │  (Stack Navigator with 40+ screen routes)               ││
+│  └─────────────────────────────────────────────────────────┘│
+├─────────────────────────────────────────────────────────────┤
+│                         Screens                              │
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐          │
+│  │Calendar │ │ Event   │ │ Account │ │  Mini   │ ...       │
+│  │ Screen  │ │ Screen  │ │ Screen  │ │  App    │          │
+│  └─────────┘ └─────────┘ └─────────┘ └─────────┘          │
+├─────────────────────────────────────────────────────────────┤
+│                       Components                             │
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐          │
+│  │ Event   │ │ Modal   │ │  Card   │ │  Form   │ ...       │
+│  │ Cards   │ │ Dialogs │ │ Layouts │ │ Inputs  │          │
+│  └─────────┘ └─────────┘ └─────────┘ └─────────┘          │
+├─────────────────────────────────────────────────────────────┤
+│                    Hooks & Utilities                         │
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐          │
+│  │ useAll  │ │  use    │ │  use    │ │  Auth   │ ...       │
+│  │ Events  │ │ Rewards │ │ Wallet  │ │ Utils   │          │
+│  └─────────┘ └─────────┘ └─────────┘ └─────────┘          │
+├─────────────────────────────────────────────────────────────┤
+│                      API Layer                               │
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │   dpop.ts (main API client)    │    src/api/* modules   ││
+│  └─────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+              ┌─────────────────────────────────┐
+              │         Backend Services         │
+              │  api.detroiter.network          │
+              │  events.builddetroit.xyz        │
+              │  dpop.nyc3.digitaloceanspaces   │
+              └─────────────────────────────────┘
+```
+
+## Navigation Architecture
+
+The app uses a single Stack Navigator (`HomeNavigationStack`) that contains all screen routes. This provides:
+- Simple, predictable navigation flow
+- Consistent header styling via theme
+- Deep link support
+
+### Screen Routes
+
+The navigation stack includes 40+ screens covering:
+- **Core**: Calendar, Event, Search, Map
+- **Account**: Login, Account, AccountManagement, FarcasterProfile
+- **Social**: Connections, SharedEvents, QRCode
+- **Content**: Art, Artwork, AddContent, ContentUpload
+- **Features**: MiniApp, Wallet, Restaurants, BestOf, Games, Fitness, Tech
+- **Admin**: Admin, ReviewEvents, EventEdit, BlockSubmissions
+
+See `src/Navigation/HomeNavigationStack.tsx` for the complete route list.
+
+## State Management
+
+### Context Providers
+
+The app uses React Context for global state instead of Redux/MobX:
+
+| Context | Purpose | Location |
+|---------|---------|----------|
+| `LocalStorageProvider` | AsyncStorage wrapper with getters/setters | `src/context/LocalStorage.tsx` |
+| `TenantProvider` | Multi-tenant configuration (city/location) | `src/context/TenantContext.tsx` |
+| `AuthProvider` | User authentication state and session | `src/context/Auth.tsx` |
+| `FarcasterFrameProvider` | Farcaster frame/auth integration | `src/context/FarcasterFrame.tsx` |
+| `AudioPlayerProvider` | Audio playback state | `src/context/AudioPlayer.tsx` |
+| `Web3Provider` | Wallet and blockchain state | `src/context/Web3.tsx` |
+
+### Local Storage
+
+Persistent data is stored via `AsyncStorage`:
+- User session tokens (`DPoPToken`, `DPoPUser`, `DPoPContact`)
+- Bookmarks and saved events
+- Check-in history
+- Rewards points and badges
+- Connection data
+
+## API Layer
+
+### Primary API Client (`src/dpop.ts`)
+
+The main API client handles:
+- Authentication (login, register, token management)
+- Events (CRUD, RSVPs, check-ins, comments)
+- Content (upload, create, update)
+- Media uploads (images, video, audio)
+- User management
+
+**Base URL:** `https://api.detroiter.network`
+
+### API Modules (`src/api/`)
+
+Specialized API modules for specific features:
+- `user.ts` – User profile operations
+- `connections.ts` – Social connections
+- `bookmarks.ts` – Event bookmarks
+- `sports-games.ts` – Sports data
+- `send-usdc.ts`, `usdc-balance.ts` – USDC transactions
+- `treasury.ts` – Treasury balance
+
+### External Data Sources
+
+Events are aggregated from multiple sources via hooks:
+- **Luma** (`useLumaEvents.ts`)
+- **Resident Advisor** (`useRAEvents.ts`)
+- **Meetup** (`useMeetupEvents.ts`)
+- **Instagram** (`useInstagramEvents.ts`)
+- **Renaissance** (`useRenaissanceEvents.ts`)
+
+## Theming System
+
+### Theme Definition (`src/colors.ts`)
+
+The app supports dark and light themes with semantic color tokens:
+
+```typescript
+export const darkTheme = {
+  // Base colors
+  background: '#121212',
+  surface: '#1E1E1E',
+  text: '#FFFFFF',
+  textSecondary: '#B0B0B0',
+  
+  // Brand colors
+  primary: '#3449ff',
+  primaryLight: '#6B7FFF',
+  
+  // Status colors
+  success: '#10B981',
+  error: '#EF4444',
+  warning: '#F59E0B',
+  
+  // Event source colors
+  eventLuma: '#ff6b6b',
+  eventRA: '#7c3aed',
+  eventMeetup: '#f97316',
+  // ...
+};
+```
+
+Theme is applied via:
+- Navigation header styles
+- Component StyleSheet definitions
+- Direct color references
+
+## Component Architecture
+
+### Screen Components
+
+Screens in `src/Screens/` are full-page views that:
+- Receive navigation props
+- Fetch data via hooks
+- Compose UI from components
+- Handle user interactions
+
+### Reusable Components
+
+Components in `src/Components/` are reusable UI elements:
+- **Event Cards** – Display event information (Luma, RA, Meetup variants)
+- **Modals** – Bottom sheets and overlays (Wallet, Bookmarks, Search)
+- **Forms** – Input groups and pickers
+- **Layout** – Sections, headers, carousels
+
+### Styled Components
+
+`src/Components/Styled/` contains themed UI primitives for consistent styling.
+
+## Custom Hooks
+
+Hooks in `src/hooks/` encapsulate:
+- Data fetching logic
+- State management
+- Side effects
+
+### Data Hooks Pattern
+
+```typescript
+export const useEvents = () => {
+  const [events, setEvents] = useState<DAEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    fetchEvents()
+      .then(setEvents)
+      .catch(setError)
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { events, loading, error, refetch };
+};
+```
+
+## Interface Definitions
+
+TypeScript interfaces are defined in:
+- `src/interfaces.ts` – Main interface file
+- `src/interfaces/` – Additional modules
+
+Key interfaces:
+- `DAEvent`, `DAVenue`, `DAUser`, `DAContent` – Core domain types
+- `LumaEvent`, `RAEvent`, `MeetupEvent` – External source types
+- `RenaissanceEvent` – Internal event type
+- `Contact`, `User` – User types
+- `ContentUpload`, `DAUpload` – Media types
+
+## Deep Linking
+
+The app handles deep links for:
+- Authentication callbacks (`renaissance://authenticate?token=...`)
+- Shared URLs (http/https)
+- Share sheet intents
+
+Deep link handling is configured in `App.tsx` and `app.json`.
+
+## Push Notifications
+
+Expo Notifications is configured for:
+- Push token registration
+- Notification handling
+- Background notification processing
+
+See `App.tsx` for notification setup.
+
+## OTA Updates
+
+Expo Updates enables over-the-air updates:
+- Configured in `app.json` under `updates`
+- Auto-reload on app foreground (`checkForUpdates`)
+- Uses EAS Update service

--- a/wiki/contributing.md
+++ b/wiki/contributing.md
@@ -1,0 +1,289 @@
+# Contributing Guide
+
+Welcome to the Renaissance project! This guide covers how to contribute effectively.
+
+## Getting Started
+
+1. Read the [Project Overview](./project-overview.md) to understand what we're building
+2. Follow [Local Development Setup](./local-dev-setup.md) to get the app running
+3. Review the [Architecture](./architecture.md) to understand the codebase structure
+
+## Branch Naming Conventions
+
+Use descriptive branch names with prefixes:
+
+| Prefix | Use Case | Example |
+|--------|----------|---------|
+| `feature/` | New features | `feature/add-event-reminders` |
+| `fix/` | Bug fixes | `fix/calendar-scroll-crash` |
+| `refactor/` | Code refactoring | `refactor/event-card-components` |
+| `docs/` | Documentation | `docs/update-setup-guide` |
+| `chore/` | Maintenance tasks | `chore/update-dependencies` |
+| `test/` | Test additions | `test/add-hook-tests` |
+
+**Format:** `prefix/short-description`
+
+**Examples:**
+- `feature/farcaster-profile-view`
+- `fix/bookmark-sync-issue`
+- `refactor/split-calendar-screen`
+
+## Commit Style
+
+### Commit Message Format
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**Types:**
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation only
+- `style`: Formatting, no code change
+- `refactor`: Code refactoring
+- `test`: Adding tests
+- `chore`: Maintenance
+
+**Examples:**
+```
+feat(events): add RSVP confirmation modal
+
+- Show confirmation before RSVP submission
+- Add loading state during API call
+- Handle error cases with toast notification
+
+Closes #123
+```
+
+```
+fix(calendar): prevent crash on empty event list
+
+Handle null check in event grouping function
+when no events are returned from API.
+```
+
+### Guidelines
+
+- Use imperative mood ("add" not "added")
+- Keep subject line under 50 characters
+- Wrap body at 72 characters
+- Reference issues in footer
+
+## Pull Request Process
+
+### Before Creating a PR
+
+1. **Ensure tests pass** (when applicable)
+2. **Verify the app runs** on both iOS and Android simulators
+3. **Check for TypeScript errors**: `npx tsc --noEmit`
+4. **Update documentation** if your changes affect it
+5. **Keep changes focused** – one feature/fix per PR
+
+### PR Template
+
+When creating a PR, include:
+
+```markdown
+## Description
+Brief description of what this PR does.
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## How Has This Been Tested?
+- [ ] iOS Simulator
+- [ ] Android Emulator
+- [ ] Physical device
+
+## Screenshots (if applicable)
+[Add screenshots for UI changes]
+
+## Checklist
+- [ ] Code follows project style guidelines
+- [ ] Self-review completed
+- [ ] Commented complex code
+- [ ] Documentation updated
+- [ ] No new warnings introduced
+```
+
+### Review Process
+
+1. Create PR against `main` branch
+2. Request review from team members
+3. Address feedback and iterate
+4. Squash and merge when approved
+
+## Code Style Guidelines
+
+### TypeScript
+
+- Enable strict mode (`"strict": true`)
+- Use explicit types for function parameters and return values
+- Prefer interfaces over type aliases for object shapes
+- Use `const` assertions where appropriate
+
+```typescript
+// Good
+interface EventCardProps {
+  event: DAEvent;
+  onPress: (event: DAEvent) => void;
+  showBookmark?: boolean;
+}
+
+// Avoid
+type EventCardProps = {
+  event: any;
+  onPress: Function;
+}
+```
+
+### React Components
+
+- Use functional components with hooks
+- Keep components focused and small
+- Extract reusable logic into custom hooks
+- Use destructuring for props
+
+```typescript
+// Good
+const EventCard: React.FC<EventCardProps> = ({ event, onPress }) => {
+  const { title, startDate, venue } = event;
+  
+  return (
+    <TouchableOpacity onPress={() => onPress(event)}>
+      <Text>{title}</Text>
+    </TouchableOpacity>
+  );
+};
+
+// Avoid
+function EventCard(props) {
+  return (
+    <TouchableOpacity onPress={() => props.onPress(props.event)}>
+      <Text>{props.event.title}</Text>
+    </TouchableOpacity>
+  );
+}
+```
+
+### Styling
+
+- Use StyleSheet for performance
+- Follow the theme system for colors
+- Keep styles close to components
+- Use semantic color tokens
+
+```typescript
+// Good
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: theme.surface,
+    padding: 16,
+    borderRadius: 8,
+  },
+  title: {
+    color: theme.text,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+
+// Avoid
+<View style={{ backgroundColor: '#1E1E1E', padding: 16 }}>
+```
+
+### File Organization
+
+- One component per file
+- Group related files in directories
+- Use index files for clean exports
+- Follow existing naming conventions
+
+### Imports
+
+Order imports as:
+1. React/React Native
+2. Third-party libraries
+3. Local components
+4. Local utilities
+5. Types/interfaces
+6. Assets
+
+```typescript
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+import { NavigationProp } from '@react-navigation/native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { EventCard } from '../Components/EventCard';
+import { theme } from '../colors';
+
+import { useEvents } from '../hooks/useEvents';
+import { formatDate } from '../utils/formatDate';
+
+import { DAEvent } from '../interfaces';
+```
+
+## Testing
+
+### Current State
+
+The project does not currently have a comprehensive test suite. When adding tests:
+
+- Use Jest (included with Expo)
+- Use React Native Testing Library for component tests
+- Mock native modules appropriately
+
+### Test File Naming
+
+- `ComponentName.test.tsx` – Component tests
+- `hookName.test.ts` – Hook tests
+- `utilName.test.ts` – Utility tests
+
+### Running Tests
+
+```bash
+# Run all tests
+yarn test
+
+# Run with coverage
+yarn test --coverage
+
+# Watch mode
+yarn test --watch
+```
+
+## Documentation
+
+### When to Update Docs
+
+Update documentation when:
+- Adding new features
+- Changing API contracts
+- Modifying configuration
+- Adding new dependencies
+
+### Documentation Files
+
+- `wiki/` – Developer documentation
+- Code comments – Complex logic only
+- README.md – Project overview
+
+## Questions & Support
+
+- **Slack/Discord**: Join the buidl-renaissance community channels
+- **GitHub Issues**: Report bugs or request features
+- **Code Reviews**: Ask questions in PR comments
+
+## License
+
+By contributing to Renaissance, you agree that your contributions will be licensed under the project's license.

--- a/wiki/environment-config.md
+++ b/wiki/environment-config.md
@@ -1,0 +1,357 @@
+# Environment & Configuration
+
+This document covers environment variables, configuration files, and build profiles for the Renaissance app.
+
+## Configuration Files
+
+### `app.json`
+
+The main Expo configuration file containing:
+
+```json
+{
+  "expo": {
+    "name": "Renaissance",
+    "slug": "renaissance",
+    "scheme": "renaissance",
+    "version": "1.1.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "userInterfaceStyle": "light",
+    "splash": {
+      "image": "./assets/renaissance.png",
+      "resizeMode": "cover",
+      "backgroundColor": "#ffffff"
+    }
+  }
+}
+```
+
+**Key Fields:**
+
+| Field | Description |
+|-------|-------------|
+| `name` | Display name in app stores |
+| `slug` | URL-friendly identifier |
+| `scheme` | Deep link scheme (`renaissance://`) |
+| `version` | App version (semver) |
+| `icon` | App icon path |
+| `splash` | Splash screen configuration |
+
+**Platform Configuration:**
+
+```json
+{
+  "ios": {
+    "bundleIdentifier": "tech.dpop.renaissance",
+    "supportsTablet": true,
+    "infoPlist": {
+      "UIBackgroundModes": ["audio"],
+      "ITSAppUsesNonExemptEncryption": false,
+      "LSApplicationQueriesSchemes": ["farcaster"]
+    }
+  },
+  "android": {
+    "package": "tech.dpop.renaissance",
+    "adaptiveIcon": {
+      "foregroundImage": "./assets/adaptive-icon.png"
+    }
+  }
+}
+```
+
+**Plugins:**
+
+```json
+{
+  "plugins": [
+    "@react-native-google-signin/google-signin",
+    "expo-secure-store",
+    "expo-build-properties",
+    "@react-native-community/datetimepicker",
+    "expo-font",
+    ["react-native-vision-camera", { "enableCodeScanner": true }],
+    ["expo-share-intent", { /* iOS activation rules */ }]
+  ]
+}
+```
+
+**EAS Configuration:**
+
+```json
+{
+  "extra": {
+    "eas": {
+      "projectId": "fcef4426-6f5e-4f44-a958-c7e61c011ab6"
+    }
+  },
+  "runtimeVersion": {
+    "policy": "sdkVersion"
+  },
+  "updates": {
+    "url": "https://u.expo.dev/fcef4426-6f5e-4f44-a958-c7e61c011ab6"
+  }
+}
+```
+
+### `eas.json`
+
+EAS Build configuration with profiles:
+
+```json
+{
+  "cli": {
+    "version": ">= 3.15.1"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "channel": "development",
+      "node": "22.9.0"
+    },
+    "development-simulator": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      },
+      "node": "22.9.0"
+    },
+    "preview": {
+      "distribution": "internal",
+      "channel": "preview",
+      "node": "22.9.0"
+    },
+    "production": {
+      "channel": "production",
+      "android": {
+        "buildType": "app-bundle"
+      },
+      "ios": {
+        "simulator": false
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}
+```
+
+**Build Profiles:**
+
+| Profile | Purpose | Distribution |
+|---------|---------|--------------|
+| `development` | Local dev with dev client | Internal |
+| `development-simulator` | iOS simulator builds | Internal |
+| `preview` | Testing builds | Internal |
+| `production` | App store releases | Store |
+
+### `package.json`
+
+Key configuration in package.json:
+
+```json
+{
+  "name": "renaissance",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "postinstall": "patch-package"
+  },
+  "engines": {
+    "node": ">=20.19.0"
+  }
+}
+```
+
+### `tsconfig.json`
+
+TypeScript configuration:
+
+```json
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}
+```
+
+### `babel.config.js`
+
+Babel transpilation config:
+
+```javascript
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo']
+  };
+};
+```
+
+### `metro.config.js`
+
+Metro bundler configuration for custom resolver settings and asset extensions.
+
+## Environment Variables
+
+### Runtime Configuration
+
+Environment variables can be set via:
+1. `.env` file (with `react-native-dotenv`)
+2. EAS secrets
+3. Build-time injection
+
+### Type Definitions (`src/env.d.ts`)
+
+```typescript
+declare module '@env' {
+  export const API_URL: string;
+  export const GOOGLE_CLIENT_ID: string;
+  // Add other env vars as needed
+}
+```
+
+### Common Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `API_URL` | Backend API base URL | Optional (has default) |
+| `GOOGLE_CLIENT_ID` | Google Sign-In client ID | For Google auth |
+| `NEYNAR_API_KEY` | Neynar API key | For Farcaster features |
+| `EAS_PROJECT_ID` | EAS project identifier | In app.json |
+
+## Source Configuration
+
+### API Endpoints (`src/dpop.ts`)
+
+```typescript
+const hostname = "https://api.detroiter.network";
+```
+
+This is the primary backend API. Other endpoints:
+- `https://events.builddetroit.xyz` – Event extraction
+- `https://dpop.nyc3.digitaloceanspaces.com` – Content storage
+
+### Theme Configuration (`src/colors.ts`)
+
+Theme tokens for dark and light modes. The default theme is dark:
+
+```typescript
+export const theme = darkTheme;
+```
+
+### Rewards Configuration (`src/config/rewards.ts`)
+
+```typescript
+export const DEFAULT_REWARD_CONFIG = {
+  pointValues: {
+    event_checkin: 50,
+    create_flyer: 100,
+    referral: { referrer: 200, referee: 50 },
+    daily_login: 10,
+  },
+  conversionRate: 100, // 100 points = $1 USDC
+  minConversionAmount: 100,
+};
+```
+
+## Build Configuration
+
+### Development Build
+
+```bash
+# iOS Simulator
+npx eas build --profile development-simulator --platform ios
+
+# Android
+npx eas build --profile development --platform android
+
+# Run with dev client
+npx expo start --dev-client
+```
+
+### Preview Build
+
+```bash
+npx eas build --profile preview --platform all
+```
+
+### Production Build
+
+```bash
+npx eas build --profile production --platform all
+```
+
+### OTA Updates
+
+```bash
+# Publish update to channel
+npx eas update --branch preview --message "Description of changes"
+```
+
+## Native Configuration
+
+### iOS (`app.json` ios section)
+
+- `bundleIdentifier`: `tech.dpop.renaissance`
+- Background modes: `audio`
+- URL schemes: `renaissance`
+- Queries schemes: `farcaster`
+
+### Android (`app.json` android section)
+
+- `package`: `tech.dpop.renaissance`
+- Intent filters for share handling
+- Deep link support for http/https
+
+### Gradle Properties
+
+```json
+{
+  "android": {
+    "gradleProperties": {
+      "VisionCamera_enableCodeScanner": "true"
+    }
+  }
+}
+```
+
+## Secrets Management
+
+### Local Development
+
+1. Create `.env` file (gitignored)
+2. Add required variables
+3. Access via `@env` module
+
+### EAS Secrets
+
+For CI/CD builds, use EAS Secrets:
+
+```bash
+# Set secret
+npx eas secret:create --name GOOGLE_CLIENT_ID --value "your-value"
+
+# List secrets
+npx eas secret:list
+```
+
+### Sensitive Data Storage
+
+Runtime sensitive data uses Expo SecureStore:
+- Authentication tokens
+- Wallet keys
+- User credentials

--- a/wiki/features.md
+++ b/wiki/features.md
@@ -1,0 +1,263 @@
+# Features
+
+This document provides an overview of the key features in the Renaissance app.
+
+## Event Discovery
+
+### Calendar View
+The primary screen (`CalendarScreen`) displays events in a comprehensive calendar format:
+- Date-based grouping with visual date headers
+- Multiple view modes (list, calendar grid)
+- Pull-to-refresh for latest events
+- Infinite scroll for loading more events
+
+### Event Sources
+Events are aggregated from multiple platforms:
+
+| Source | Description | Card Component |
+|--------|-------------|----------------|
+| **Luma** | Tech and community events | `LumaEventCard.tsx` |
+| **Resident Advisor** | Music and nightlife events | `RAEventCard.tsx` |
+| **Meetup** | Group meetups and activities | `MeetupEventCard.tsx` |
+| **Instagram** | Events extracted from Instagram posts | `InstagramEventCard.tsx` |
+| **Renaissance** | Native Renaissance events | `RenaissanceEventCard.tsx` |
+| **Sports** | Local sports games | `SportsGameCard.tsx` |
+
+### Event Details
+Each event type has a dedicated detail view showing:
+- Event title, description, and image
+- Date, time, and venue information
+- RSVP and booking options
+- Share and bookmark actions
+- Check-in functionality
+
+### Filtering & Search
+- Filter by event type/source
+- Search by keyword
+- Location-based filtering (via Tenant context)
+- Date range selection
+
+## Social Features
+
+### Connections
+Connect with other Renaissance users:
+- QR code sharing for easy connection
+- Connection list management
+- View mutual connections
+- Share events with connections
+
+### Shared Events
+When connected with other users:
+- View events both users have bookmarked
+- See shared interests and overlap
+- Send event recommendations
+
+### QR Code System
+- Generate personal QR code for profile sharing
+- Scan QR codes to connect with others
+- Event check-in via QR code
+
+## Bookmarks
+
+### Save Events
+- Bookmark any event from any source
+- Organize saved events chronologically
+- Access bookmarks from dedicated screen
+- Sync bookmarks across sessions
+
+### Bookmark Lists
+- Create and manage bookmark collections
+- Share bookmark lists with connections
+- Export bookmark data
+
+## Rewards System
+
+### Points
+Earn points through engagement:
+
+| Action | Points |
+|--------|--------|
+| Event check-in | 50 |
+| Create flyer | 100 |
+| Referral (referrer) | 200 |
+| Referral (referee) | 50 |
+| Daily login | 10 |
+
+### Badges
+Earn badges for achievements:
+- Check-in milestones
+- Referral counts
+- Content creation
+- Community participation
+
+### Points Conversion
+- Convert points to USDC at 100 points = $1
+- Minimum conversion: 100 points
+- Direct transfer to connected wallet
+
+## Wallet & Web3
+
+### Wallet Management
+- View wallet address and balances
+- USDC balance display
+- Transaction history
+- Points balance and conversion
+
+### Web3 Integration
+- ethers.js for Ethereum interactions
+- CosmJS for Cosmos chain support
+- DPoP authentication protocol
+- Secure key storage via Expo SecureStore
+
+### USDC Transactions
+- Send USDC to other addresses
+- Receive USDC from points conversion
+- View transaction status
+
+## Farcaster Integration
+
+### Authentication
+- Sign in with Farcaster account
+- Neynar API integration
+- Frame support for Farcaster actions
+
+### Profile
+- View Farcaster profile information
+- Display Farcaster username and avatar
+- Link Farcaster identity to Renaissance account
+
+### Frames
+- Render Farcaster frames in-app
+- Interact with frame actions
+- Share frames with connections
+
+## Mini Apps
+
+### In-App Browser
+Load partner applications and services within the app:
+- Secure webview container
+- Message passing between app and webview
+- Deep link handling
+- Custom header with navigation controls
+
+### Available Mini Apps
+Mini apps are configured and displayed via:
+- Grid view in MiniAppsModal
+- Quick access buttons
+- URL-based launching
+
+## Content Creation
+
+### Flyer Submission
+Upload event flyers with AI-powered extraction:
+1. Select or capture flyer image
+2. AI extracts event details (title, date, venue, description)
+3. Review and edit extracted data
+4. Submit for publication
+
+### Audio Content
+- Record audio content
+- Upload audio recordings
+- Associate audio with events/artwork
+
+### Media Upload
+- Image upload with EXIF data preservation
+- Video upload support
+- Automatic resizing and optimization
+
+## Location Features
+
+### Multi-Tenant Support
+The app supports multiple locations/tenants:
+- Detroit (default)
+- Denver
+- Other cities as added
+
+Each tenant provides:
+- Location-specific events
+- Custom branding/theming
+- Regional API endpoints
+
+### Map Views
+- Browse events on map
+- Venue locations with markers
+- Direction links to mapping apps
+
+## Account Management
+
+### Profile
+- Display name and avatar
+- Bio and organization
+- Contact information
+- Attribution links
+
+### Settings
+- Notification preferences
+- Theme settings (dark/light)
+- Privacy controls
+- Data export
+
+### Authentication
+Multiple auth methods:
+- Email/password
+- Google Sign-In
+- Farcaster/Neynar
+- DPoP authentication
+
+## Restaurants & Local Discovery
+
+### Restaurant Listings
+- Browse local restaurants
+- Category filtering (pizza, tacos, etc.)
+- Rating and points system
+
+### Bucket Lists
+- Create restaurant bucket lists
+- Share with friends
+- Track visited locations
+
+### Best Of Rankings
+- Category-based rankings
+- Community voting
+- Leaderboards
+
+## Admin Features
+
+### Event Review
+Admin users can:
+- Review submitted events
+- Edit event details
+- Approve/reject submissions
+- Manage featured events
+
+### Block Submissions
+- Review community block submissions
+- Moderation tools
+- Content flagging
+
+### Grant Governance
+- Create grant proposals
+- Vote on proposals
+- Track grant disbursement
+
+## Technical Features
+
+### OTA Updates
+- Automatic updates via Expo Updates
+- Background update checking
+- Forced reload on critical updates
+
+### Deep Linking
+- Handle `renaissance://` scheme
+- Process shared URLs
+- Authentication callbacks
+
+### Push Notifications
+- Event reminders
+- Connection requests
+- System announcements
+
+### Offline Support
+- Cached event data
+- Offline bookmark access
+- Queue actions for sync

--- a/wiki/local-dev-setup.md
+++ b/wiki/local-dev-setup.md
@@ -1,0 +1,234 @@
+# Local Development Setup
+
+This guide will help you get the Renaissance app running on your local machine.
+
+## Prerequisites
+
+### Required Software
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| **Node.js** | >= 20.19.0 | Required by `engines` in package.json |
+| **Yarn** | 1.x (Classic) | Package manager |
+| **Expo CLI** | Latest | Installed globally or via npx |
+| **Watchman** | Latest | Recommended for macOS/Linux |
+
+### For iOS Development
+- macOS (required)
+- Xcode 15+ with Command Line Tools
+- iOS Simulator or physical iOS device
+- CocoaPods (`sudo gem install cocoapods`)
+
+### For Android Development
+- Android Studio with Android SDK
+- Android Emulator or physical Android device
+- Java Development Kit (JDK) 17
+
+## Installation Steps
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/buidl-renaissance/renaissance.git
+cd renaissance
+```
+
+### 2. Install Dependencies
+
+```bash
+yarn install
+```
+
+This will also run `postinstall` which applies any patches via `patch-package`.
+
+### 3. Environment Setup
+
+The app uses environment variables for API endpoints and configuration. Create a `.env` file if needed (check with the team for required values).
+
+Common environment variables:
+- API endpoints
+- Third-party API keys (Google, Neynar, etc.)
+
+### 4. Start the Development Server
+
+```bash
+# Start Expo development server
+yarn start
+
+# Or explicitly
+npx expo start
+```
+
+This opens the Expo DevTools in your browser.
+
+### 5. Run on Simulator/Emulator
+
+**iOS Simulator:**
+```bash
+yarn ios
+# Or press 'i' in the Expo DevTools terminal
+```
+
+**Android Emulator:**
+```bash
+yarn android
+# Or press 'a' in the Expo DevTools terminal
+```
+
+### 6. Run on Physical Device
+
+1. Install **Expo Go** from the App Store (iOS) or Play Store (Android)
+2. Scan the QR code shown in the terminal or Expo DevTools
+3. The app will load on your device
+
+**Note:** Some features (camera, vision camera) require a development build and won't work in Expo Go.
+
+## Development Builds
+
+For full native module access (camera, vision-camera, etc.), you need a development build:
+
+### Create Development Build
+
+```bash
+# iOS Simulator
+npx eas build --profile development-simulator --platform ios
+
+# Android
+npx eas build --profile development --platform android
+```
+
+### Run with Development Client
+
+```bash
+npx expo start --dev-client
+```
+
+## Common Scripts
+
+| Script | Command | Description |
+|--------|---------|-------------|
+| Start | `yarn start` | Start Expo dev server |
+| iOS | `yarn ios` | Run on iOS simulator |
+| Android | `yarn android` | Run on Android emulator |
+| Web | `yarn web` | Run in web browser |
+
+## Common Gotchas & Troubleshooting
+
+### Metro Bundler Issues
+
+**Clear cache and restart:**
+```bash
+npx expo start --clear
+# Or
+yarn start --clear
+```
+
+**Reset Metro cache completely:**
+```bash
+rm -rf node_modules/.cache
+watchman watch-del-all  # If using watchman
+yarn start --clear
+```
+
+### iOS Build Failures
+
+**Pod install issues:**
+```bash
+cd ios
+pod deintegrate
+pod install
+cd ..
+```
+
+**Clean Xcode build:**
+```bash
+rm -rf ios/build
+rm -rf ~/Library/Developer/Xcode/DerivedData
+```
+
+### Android Build Failures
+
+**Clean Gradle:**
+```bash
+cd android
+./gradlew clean
+cd ..
+```
+
+**Clear Android build cache:**
+```bash
+rm -rf android/app/build
+rm -rf android/.gradle
+```
+
+### Node/Yarn Issues
+
+**Node version mismatch:**
+```bash
+# Check your Node version
+node --version
+# Should be >= 20.19.0
+
+# Use nvm to switch versions
+nvm use 20
+```
+
+**Reinstall dependencies:**
+```bash
+rm -rf node_modules
+rm yarn.lock
+yarn install
+```
+
+### Camera/Vision Camera Not Working
+
+The app uses `react-native-vision-camera` which requires:
+1. A development build (not Expo Go)
+2. Physical device for full camera features
+3. Proper permissions granted
+
+See [MIGRATION_NOTES.md](../MIGRATION_NOTES.md) for camera-specific setup.
+
+### Expo Updates Not Loading
+
+If OTA updates aren't loading:
+```bash
+# Force clear Expo cache
+npx expo start --clear
+
+# Or clear Expo caches manually
+rm -rf ~/.expo
+```
+
+### TypeScript Errors
+
+**Rebuild TypeScript:**
+```bash
+npx tsc --noEmit
+```
+
+**Check tsconfig.json** for proper include/exclude paths.
+
+## Development Tips
+
+### Hot Reloading
+- Hot reloading is enabled by default
+- Press `r` in the terminal to force reload
+- Press `m` to toggle the menu
+
+### Debugging
+- Shake device or press `d` to open React Native dev menu
+- Use React DevTools for component inspection
+- Console logs appear in the terminal running Expo
+
+### Network Debugging
+- The app connects to `api.detroiter.network` for backend services
+- Use a proxy like Charles or mitmproxy to inspect network requests
+- Check `src/dpop.ts` for the base hostname configuration
+
+## Next Steps
+
+Once you have the app running:
+1. Read [Repository Structure](./repo-structure.md) to understand the codebase
+2. Review [Architecture](./architecture.md) for technical design
+3. Check [Contributing](./contributing.md) before making changes

--- a/wiki/project-overview.md
+++ b/wiki/project-overview.md
@@ -1,0 +1,76 @@
+# Project Overview
+
+## What is Renaissance?
+
+**Renaissance** is a React Native / Expo mobile application for the Renaissance community platform. It serves as a comprehensive event discovery, social networking, and community engagement app focused on connecting users with local events, art, music, and cultural experiences.
+
+The app is part of the broader `buidl-renaissance` ecosystem, which includes smart contracts, authentication protocols, and generative art components.
+
+## Who is Renaissance For?
+
+- **Event Enthusiasts** – People looking to discover local events, concerts, meetups, and cultural experiences
+- **Community Members** – Users who want to connect with like-minded individuals and share experiences
+- **Event Organizers** – People creating and promoting events, submitting flyers, and managing RSVPs
+- **Artists & Creators** – Individuals showcasing artwork and participating in the creative community
+- **Tech Enthusiasts** – Users interested in Web3 features, Farcaster integration, and blockchain-based rewards
+
+## High-Level Goals
+
+### Core User Value
+- Aggregate events from multiple sources (Luma, Resident Advisor, Meetup, Instagram, local submissions)
+- Provide a unified calendar and discovery experience for local events
+- Enable social features like bookmarking, sharing, and connecting with other users
+- Reward community participation through a points/rewards system
+
+### Technical Goals
+- Build a performant, cross-platform mobile app with React Native and Expo
+- Integrate with Web3 protocols (DPoP authentication, wallet support, USDC transactions)
+- Support Farcaster frames and social authentication
+- Maintain a clean, themeable UI with dark mode support
+
+### Community Goals
+- Foster local community engagement through shared events
+- Enable decentralized identity and authentication
+- Support content creation and curation by community members
+
+## Key Features
+
+- **Event Discovery** – Browse events from multiple aggregated sources
+- **Calendar View** – Visual calendar with event grouping and filtering
+- **Social Connections** – Connect with other users, share events, view shared bookmarks
+- **Bookmarks** – Save events and share bookmark lists with connections
+- **Rewards System** – Earn points for check-ins, referrals, and engagement
+- **Mini Apps** – In-app webview for partner applications and services
+- **Wallet Integration** – View balances, convert points to USDC, manage Web3 identity
+- **Farcaster Integration** – Authenticate with Farcaster, view profiles, support frames
+- **Flyer Submission** – Upload event flyers with AI-powered data extraction
+- **QR Code Sharing** – Share profiles and connect via QR codes
+- **Multi-tenant Support** – Location-based experiences (Detroit, Denver, etc.)
+
+## Related Repositories
+
+| Repository | Description |
+|------------|-------------|
+| [renaissance-contracts](https://github.com/buidl-renaissance/renaissance-contracts) | Smart contracts for Renaissance ecosystem |
+| [dpop](https://github.com/buidl-renaissance/dpop) | DPoP (Decentralized Proof of Participation) authentication |
+| [regen-art](https://github.com/buidl-renaissance/regen-art) | Generative art components and tools |
+
+## Backend Services
+
+The app communicates with several backend services:
+
+- **Detroiter Network API** (`api.detroiter.network`) – Primary backend for events, users, content
+- **Events Build Detroit** (`events.builddetroit.xyz`) – Event extraction and flyer processing
+- **DPoP Spaces** (`dpop.nyc3.digitaloceanspaces.com`) – Content storage
+
+## Tech Stack Summary
+
+- **Framework**: React Native 0.81.x with Expo SDK 54
+- **Language**: TypeScript
+- **Navigation**: React Navigation (Stack + Bottom Tabs)
+- **State Management**: React Context API
+- **Styling**: StyleSheet (inline), with theme support
+- **Web3**: ethers.js, CosmJS
+- **Authentication**: DPoP, Farcaster/Neynar, Google Sign-In
+
+For detailed technical architecture, see [Architecture](./architecture.md).

--- a/wiki/repo-structure.md
+++ b/wiki/repo-structure.md
@@ -1,0 +1,221 @@
+# Repository Structure
+
+This document provides an annotated tour of the Renaissance repository structure.
+
+## Root Directory
+
+```
+renaissance/
+├── App.tsx              # Main application entry point
+├── app.json             # Expo configuration (name, plugins, native settings)
+├── eas.json             # EAS Build configuration (dev/preview/production profiles)
+├── package.json         # Dependencies and scripts
+├── tsconfig.json        # TypeScript configuration
+├── babel.config.js      # Babel configuration
+├── metro.config.js      # Metro bundler configuration
+├── yarn.lock            # Yarn lockfile
+├── assets/              # Static assets (icons, images, fonts)
+├── src/                 # Application source code
+└── wiki/                # Developer documentation (this wiki)
+```
+
+## `App.tsx`
+
+The main entry point that:
+- Imports polyfills (`text-encoding-polyfill`)
+- Sets up React Navigation container
+- Configures push notifications (Expo Notifications)
+- Handles deep links and share intents
+- Wraps the app in context providers:
+  - `GestureHandlerRootView`
+  - `LocalStorageProvider`
+  - `TenantProvider`
+  - `AuthProvider`
+  - `FarcasterFrameProvider`
+  - `AudioPlayerProvider`
+  - `BottomSheetModalProvider`
+  - `NavigationContainer`
+
+## `src/` Directory
+
+### `src/api/`
+API client modules for backend communication.
+
+| File | Purpose |
+|------|---------|
+| `user.ts` | User-related API calls (profile, settings) |
+| `connections.ts` | Social connections API |
+| `bookmarks.ts` | Event bookmarks API |
+| `sports-games.ts` | Sports games data |
+| `featured-events.ts` | Featured events listing |
+| `block-submissions.ts` | Community block submissions |
+| `send-usdc.ts` | USDC transfer functionality |
+| `usdc-balance.ts` | USDC balance queries |
+| `treasury.ts` | Treasury balance queries |
+| `web3.ts` | Web3 utility functions |
+| `convert-points.ts` | Points-to-USDC conversion |
+| `grant-governance.ts` | Grant governance features |
+
+### `src/Screens/`
+Screen components for each view in the app. Major screens include:
+
+| Screen | Purpose |
+|--------|---------|
+| `CalendarScreen.tsx` | Main event calendar (56KB, primary landing screen) |
+| `AccountManagementScreen.tsx` | User account settings (58KB) |
+| `SharedURLScreen.tsx` | Handle shared URLs from other apps |
+| `MiniAppScreen.tsx` | In-app webview for mini apps |
+| `WalletScreen.tsx` | Web3 wallet management |
+| `EventScreen.tsx` | Individual event detail view |
+| `RenaissanceEventScreen.tsx` | Renaissance-specific event view |
+| `FarcasterProfileScreen.tsx` | Farcaster profile display |
+| `LoginScreen.tsx` | Authentication flow |
+| `SearchScreen.tsx` | Event and content search |
+| `MapScreen.tsx` / `BrowseMapScreen.tsx` | Map-based event browsing |
+| `RestaurantsScreen.tsx` | Restaurant discovery feature |
+| `BookmarksScreen.tsx` | Saved events view |
+| `ConnectionsScreen.tsx` | Social connections management |
+
+### `src/Components/`
+Reusable UI components organized by feature.
+
+**Event-related:**
+- `EventCard.tsx`, `EventRenderer.tsx`, `EventsSectionList.tsx`
+- `LumaEventCard.tsx`, `RAEventCard.tsx`, `MeetupEventCard.tsx`
+- `InstagramEventCard.tsx`, `RenaissanceEventCard.tsx`
+- `EventBookmarkButton.tsx`, `EventCheckInButton.tsx`
+- `EventWebModal.tsx`, `DAEventModal.tsx`
+- `CreateFlyerModal.tsx`, `EventForecast.tsx`
+
+**Navigation & Modals:**
+- `MiniAppModal.tsx`, `MiniAppsModal.tsx`, `MiniAppButton.tsx`
+- `BookmarksModal.tsx`, `BookmarksContent.tsx`
+- `ConnectionsModal.tsx`, `ConnectionsContent.tsx`
+- `WalletModal.tsx`, `QRCodeModal.tsx`, `SearchModal.tsx`
+- `DismissibleScrollModal.tsx`, `InstagramPostModal.tsx`
+
+**User & Social:**
+- `ConnectionAvatars.tsx`
+- `FarcasterProfileScreen.tsx` (in Screens)
+- `BadgeDisplay.tsx`
+
+**UI Primitives:**
+- `Button.tsx`, `Icon.tsx`, `RoundButton.tsx`
+- `Carousel.tsx`, `CategoryChip.tsx`, `FilterBubble.tsx`
+- `SectionHeader.tsx`, `SectionTitle.tsx`
+- `DateTimePicker.tsx`, `TextInputGroup.tsx`
+
+**Styled Components:** `src/Components/Styled/` – Themed UI primitives
+
+**Content:** `src/Components/Content/` – Content display components
+
+### `src/Navigation/`
+Navigation configuration.
+
+| File | Purpose |
+|------|---------|
+| `HomeNavigationStack.tsx` | Main stack navigator with all screen routes |
+| `BottomTabNavigator.tsx` | Bottom tab navigation (if enabled) |
+
+### `src/context/`
+React Context providers for global state.
+
+| Context | Purpose |
+|---------|---------|
+| `Auth.tsx` | Authentication state and user session |
+| `LocalStorage.tsx` | AsyncStorage wrapper for persistent data |
+| `TenantContext.tsx` | Multi-tenant/location configuration |
+| `FarcasterFrame.tsx` | Farcaster frame and auth integration |
+| `AudioPlayer.tsx` | Audio playback state |
+| `AudioRecorder.tsx` | Audio recording state |
+| `Web3.tsx` | Web3/wallet provider |
+
+### `src/hooks/`
+Custom React hooks for data fetching and utilities.
+
+**Event hooks:**
+- `useAllEvents.ts` – Aggregated events from all sources
+- `useEvents.ts` – Generic event fetching
+- `useLumaEvents.ts`, `useRAEvents.ts`, `useMeetupEvents.ts`
+- `useInstagramEvents.ts`, `useRenaissanceEvents.ts`
+- `useDenverEvents.ts`, `useEthDenverEvents.ts`
+- `useFeaturedRAEvents.ts`
+
+**Utility hooks:**
+- `useArtwork.ts` – Artwork data
+- `useVenues.ts` – Venue data
+- `useWeather.ts` – Weather forecasts
+- `useSportsGames.ts` – Sports game schedules
+- `useRewards.ts` – Rewards/points system
+- `useConnectionBookmarks.ts` – Shared bookmarks
+- `useUSDCBalance.ts`, `useTreasuryBalance.ts` – Web3 balances
+
+**Camera/Media:**
+- `useVisionCamera.ts` – react-native-vision-camera wrapper
+- `useBarcodeScanner.ts` – QR/barcode scanning
+- `useImagePicker.ts` – Image selection
+- `useWebModal.ts` – Web modal state
+
+### `src/interfaces/`
+TypeScript type definitions.
+
+- `src/interfaces.ts` – Main interface file with event, user, venue, and API types
+- `src/interfaces/` directory – Additional interface modules
+
+Key interfaces: `DAEvent`, `DAVenue`, `DAUser`, `DAContent`, `DAArtwork`, `LumaEvent`, `RAEvent`, `MeetupEvent`, `RenaissanceEvent`
+
+### `src/utils/`
+Utility functions and helpers.
+
+| File | Purpose |
+|------|---------|
+| `bookmarks.ts` | Bookmark storage and sync |
+| `connections.ts` | Connection management |
+| `eventDates.ts`, `eventGrouping.ts`, `eventKeys.ts` | Event date/grouping utilities |
+| `event-checkin.ts` | Check-in logic |
+| `farcasterAuth.ts`, `farcasterSigner.ts` | Farcaster authentication |
+| `neynarAuth.ts` | Neynar API authentication |
+| `rewards-storage.ts` | Rewards persistence |
+| `sharedEvents.ts`, `sharedUrls.ts` | Sharing utilities |
+| `urlDetection.ts` | URL parsing and detection |
+| `wallet.ts`, `web3.ts` | Web3 utilities |
+| `badges.ts` | Badge system |
+| `bucketLists.ts` | Restaurant bucket lists |
+| `formatDate.ts`, `formatTime.ts` | Date/time formatting |
+| `uploadImage.ts` | Image upload helpers |
+| `checkForUpdate.ts` | OTA update checking |
+
+### `src/config/`
+Configuration files.
+
+- `rewards.ts` – Rewards system configuration (point values, conversion rates)
+
+### `src/mocks/`
+Mock data for development and testing.
+
+### `src/build/`
+Build-related utilities and scripts.
+
+### Other Root Files
+
+- `src/dpop.ts` – DPoP API client (authentication, events, content, media upload)
+- `src/colors.ts` – Theme definitions (dark/light themes, colors, semantic tokens)
+- `src/env.d.ts` – Environment variable type declarations
+
+## `assets/`
+
+Static assets directory:
+- `icon.png` – App icon
+- `adaptive-icon.png` – Android adaptive icon
+- `splash.png` / `renaissance.png` – Splash screen
+- `favicon.png` – Web favicon
+
+## Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `app.json` | Expo configuration (plugins, native settings, EAS project ID) |
+| `eas.json` | EAS Build profiles (development, preview, production) |
+| `tsconfig.json` | TypeScript compiler options |
+| `babel.config.js` | Babel transpilation config |
+| `metro.config.js` | Metro bundler settings |

--- a/wiki/tools.md
+++ b/wiki/tools.md
@@ -1,0 +1,229 @@
+# Tools & Dependencies
+
+This document covers the key libraries, tools, and dependencies used in the Renaissance app.
+
+## Core Framework
+
+### React Native & Expo
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `react` | 19.1.0 | UI library |
+| `react-native` | 0.81.5 | Mobile framework |
+| `expo` | ^54.0.0 | Development platform |
+| `typescript` | ~5.9.2 | Type system |
+
+### Build Tools
+
+| Package | Purpose |
+|---------|---------|
+| `@babel/core` | JavaScript transpilation |
+| `metro` | React Native bundler |
+| `patch-package` | Apply patches to node_modules |
+
+## Navigation
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `@react-navigation/native` | ^6.0.10 | Navigation foundation |
+| `@react-navigation/stack` | ^6.2.1 | Stack navigator |
+| `@react-navigation/bottom-tabs` | ^6.3.1 | Tab navigator |
+| `@react-navigation/material-top-tabs` | ^6.2.1 | Top tab navigator |
+| `react-native-screens` | ~4.16.0 | Native navigation screens |
+
+## UI Components
+
+### Core UI
+
+| Package | Purpose |
+|---------|---------|
+| `react-native-paper` | Material Design components |
+| `@gorhom/bottom-sheet` | Bottom sheet modals |
+| `react-native-modal` | Modal dialogs |
+| `react-native-super-grid` | Grid layouts |
+| `react-native-tab-view` | Tab view component |
+| `react-native-pager-view` | Swipeable pages |
+
+### Gestures & Animation
+
+| Package | Purpose |
+|---------|---------|
+| `react-native-gesture-handler` | Touch gestures |
+| `react-native-reanimated` | Smooth animations |
+| `react-native-safe-area-context` | Safe area handling |
+
+### Input & Forms
+
+| Package | Purpose |
+|---------|---------|
+| `@react-native-community/datetimepicker` | Date/time picker |
+| `@react-native-picker/picker` | Dropdown picker |
+| `react-native-modal-datetime-picker` | Modal date picker |
+| `react-native-modal-selector` | Modal selector |
+| `react-native-searchable-dropdown` | Searchable dropdown |
+| `react-native-autocomplete-dropdown` | Autocomplete input |
+| `react-native-keyboard-controller` | Keyboard handling |
+
+### Icons & Graphics
+
+| Package | Purpose |
+|---------|---------|
+| `@expo/vector-icons` | Icon library |
+| `react-native-svg` | SVG support |
+| `react-native-qrcode-svg` | QR code generation |
+| `react-qr-code` | QR code (web) |
+
+### Content Display
+
+| Package | Purpose |
+|---------|---------|
+| `react-native-render-html` | HTML rendering |
+| `react-native-webview` | Web content |
+| `react-native-youtube-iframe` | YouTube videos |
+| `react-native-gifted-chat` | Chat UI |
+
+## Expo Modules
+
+| Module | Purpose |
+|--------|---------|
+| `expo-av` | Audio/video playback |
+| `expo-camera` | Camera access (legacy) |
+| `expo-crypto` | Cryptographic operations |
+| `expo-dev-client` | Development client |
+| `expo-device` | Device information |
+| `expo-file-system` | File operations |
+| `expo-font` | Custom fonts |
+| `expo-image-manipulator` | Image editing |
+| `expo-image-picker` | Image selection |
+| `expo-linking` | Deep linking |
+| `expo-media-library` | Media access |
+| `expo-notifications` | Push notifications |
+| `expo-random` | Random number generation |
+| `expo-secure-store` | Secure storage |
+| `expo-share-intent` | Share sheet handling |
+| `expo-splash-screen` | Splash screen |
+| `expo-status-bar` | Status bar control |
+| `expo-updates` | OTA updates |
+
+## Camera & Vision
+
+| Package | Purpose |
+|---------|---------|
+| `react-native-vision-camera` | Modern camera API |
+| `react-native-worklets` | Camera frame processing |
+
+See [MIGRATION_NOTES.md](../MIGRATION_NOTES.md) for camera migration details.
+
+## Web3 & Blockchain
+
+### Ethereum
+
+| Package | Purpose |
+|---------|---------|
+| `ethers` | Ethereum library |
+| `@ethersproject/shims` | React Native shims |
+| `react-native-get-random-values` | Crypto polyfill |
+
+### Cosmos
+
+| Package | Purpose |
+|---------|---------|
+| `@cosmjs/amino` | Amino signing |
+| `@cosmjs/proto-signing` | Protobuf signing |
+| `@cosmjs/stargate` | Stargate client |
+
+### Cryptography
+
+| Package | Purpose |
+|---------|---------|
+| `@noble/ed25519` | Ed25519 signatures |
+| `@noble/hashes` | Hash functions |
+| `buffer` | Buffer polyfill |
+| `text-encoding-polyfill` | TextEncoder polyfill |
+
+## Authentication
+
+| Package | Purpose |
+|---------|---------|
+| `@react-native-google-signin/google-signin` | Google Sign-In |
+| `@farcaster/frame-host-react-native` | Farcaster frames |
+
+## Data & Storage
+
+| Package | Purpose |
+|---------|---------|
+| `@react-native-async-storage/async-storage` | Persistent storage |
+| `@react-native-community/netinfo` | Network status |
+| `react-native-event-listeners` | Event bus |
+
+## Date & Time
+
+| Package | Purpose |
+|---------|---------|
+| `date-fns` | Date manipulation |
+| `moment` | Date parsing |
+| `moment-timezone` | Timezone support |
+
+## Utilities
+
+| Package | Purpose |
+|---------|---------|
+| `html-entities` | HTML entity decoding |
+| `react-native-dotenv` | Environment variables |
+| `@react-native-anywhere/polyfill-base64` | Base64 polyfill |
+
+## Maps
+
+| Package | Purpose |
+|---------|---------|
+| `react-native-maps` | Native maps |
+
+## Development Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `@babel/core` | Babel compiler |
+| `@types/react` | React type definitions |
+| `patch-package` | Dependency patching |
+| `postinstall-postinstall` | Post-install hooks |
+
+## CLI Tools (Global)
+
+These tools should be installed globally or accessed via npx:
+
+| Tool | Purpose |
+|------|---------|
+| `expo-cli` | Expo development |
+| `eas-cli` | EAS Build/Update |
+| `react-native` | RN commands |
+
+## Recommended VS Code Extensions
+
+| Extension | Purpose |
+|-----------|---------|
+| ES7+ React/Redux/React-Native snippets | Code snippets |
+| ESLint | Code linting |
+| Prettier | Code formatting |
+| TypeScript Hero | TS organization |
+| React Native Tools | Debugging |
+| Expo Tools | Expo integration |
+
+## Version Compatibility
+
+The app targets:
+- **Node.js**: >= 20.19.0
+- **React Native**: 0.81.x
+- **Expo SDK**: 54
+- **TypeScript**: 5.9.x
+- **iOS**: 13.4+
+- **Android**: API 21+
+
+## Dependency Updates
+
+When updating dependencies:
+
+1. Check Expo SDK compatibility first
+2. Review React Native upgrade guides
+3. Test on both iOS and Android
+4. Update patch files if needed (`patches/` directory)
+5. Run `yarn postinstall` to apply patches


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Scope
- Allowed: new or updated markdown under `wiki/`, and **at most** adding or adjusting a single line in root `README.md` that links to `wiki/README.md` if no such link exists.
- Not allowed: feature code, refactors, package.json / lockfile changes, new dependencies.

### What changed
- Created `wiki/` directory with 10 comprehensive documentation files:
  - `wiki/README.md` - Index with table of contents linking all wiki pages
  - `wiki/project-overview.md` - What Renaissance is, who it's for, high-level goals
  - `wiki/repo-structure.md` - Annotated tour of the codebase layout
  - `wiki/local-dev-setup.md` - Prerequisites, installation, running the app, troubleshooting
  - `wiki/architecture.md` - Technical architecture, state management, API layer
  - `wiki/features.md` - Overview of app features and capabilities
  - `wiki/environment-config.md` - Environment variables and build configuration
  - `wiki/tools.md` - Key libraries and dependencies used
  - `wiki/contributing.md` - Branch naming, commit style, PR process, code guidelines
  - `wiki/AGENTS.md` - Instructions for AI agents working on this codebase
- Created root `README.md` with link to wiki (no previous README existed)

### How to verify
- Open any `wiki/*.md` file on GitHub - all render cleanly as Markdown
- Verify `wiki/README.md` index links work and navigate correctly
- Check that root `README.md` links to `wiki/README.md`
- Review documentation accuracy against actual codebase structure

### Wiki bootstrap (required before merge)
- [x] `wiki/README.md` exists with an index table linking architecture, features, tools, AGENTS
- [x] `wiki/architecture.md`, `wiki/features.md`, `wiki/tools.md`, `wiki/AGENTS.md` exist with honest stubs or real content
- [x] Root `README.md` includes a clear link to `wiki/README.md` (add one line if missing only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b56a63fa-db16-4ba8-8279-d4477069dab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b56a63fa-db16-4ba8-8279-d4477069dab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

