### PR TITLE
Add EAS auto-deploy pipeline for CI/CD

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,88 @@
+name: EAS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform to build for'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - android
+          - ios
+      profile:
+        description: 'Build profile'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - development
+          - preview
+          - production
+      submit:
+        description: 'Submit to stores after build'
+        required: false
+        default: false
+        type: boolean
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: EAS Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for EXPO_TOKEN
+        run: |
+          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
+            echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets."
+            echo "Learn more: https://docs.expo.dev/eas-update/github-actions/"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: yarn
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Determine build parameters
+        id: params
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "platform=all" >> $GITHUB_OUTPUT
+            echo "profile=production" >> $GITHUB_OUTPUT
+            echo "submit=true" >> $GITHUB_OUTPUT
+          else
+            echo "platform=${{ github.event.inputs.platform }}" >> $GITHUB_OUTPUT
+            echo "profile=${{ github.event.inputs.profile }}" >> $GITHUB_OUTPUT
+            echo "submit=${{ github.event.inputs.submit }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build app
+        run: |
+          PLATFORM_FLAG=""
+          if [ "${{ steps.params.outputs.platform }}" != "all" ]; then
+            PLATFORM_FLAG="--platform ${{ steps.params.outputs.platform }}"
+          fi
+          
+          SUBMIT_FLAG=""
+          if [ "${{ steps.params.outputs.submit }}" = "true" ]; then
+            SUBMIT_FLAG="--auto-submit"
+          fi
+          
+          eas build --profile ${{ steps.params.outputs.profile }} $PLATFORM_FLAG $SUBMIT_FLAG --non-interactive

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -1,0 +1,46 @@
+name: EAS Update
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      message:
+        description: 'Update message'
+        required: false
+        default: 'Manual update'
+
+jobs:
+  update:
+    name: EAS Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for EXPO_TOKEN
+        run: |
+          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
+            echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets."
+            echo "Learn more: https://docs.expo.dev/eas-update/github-actions/"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: yarn
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Publish update
+        run: eas update --auto --non-interactive --message "${{ github.event.inputs.message || github.event.head_commit.message }}"

--- a/eas.json
+++ b/eas.json
@@ -24,6 +24,7 @@
     },
     "production": {
       "channel": "production",
+      "node": "22.9.0",
       "android": {
         "buildType": "app-bundle"
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR sets up an automated EAS (Expo Application Services) build and deploy pipeline using GitHub Actions.

## Changes

### EAS Update Workflow (`.github/workflows/eas-update.yml`)
- **Triggers on push to `main` branch** - Automatically publishes OTA (Over-The-Air) updates
- Uses the commit message as the update message for easy tracking
- Can also be triggered manually via `workflow_dispatch` with a custom message
- Leverages `expo-updates` which is already configured in the app

### EAS Build Workflow (`.github/workflows/eas-build.yml`)
- **Triggers on GitHub release publish** - Automatically builds production apps for both platforms
- Can be manually triggered with options for:
  - Platform selection (all, android, ios)
  - Build profile (development, preview, production)
  - Auto-submit to app stores option
- Supports automatic submission to App Store and Play Store

### Configuration Updates (`eas.json`)
- Added `node: "22.9.0"` to production profile for consistency with other profiles

## Setup Required

To enable these workflows, you need to add the `EXPO_TOKEN` secret to this repository:

1. Go to [Expo Access Tokens](https://expo.dev/accounts/[account]/settings/access-tokens)
2. Create a new access token
3. Add it as a repository secret named `EXPO_TOKEN` in GitHub Settings → Secrets → Actions

## How It Works

- **Push to main** → EAS Update publishes a JS bundle update that users receive automatically
- **Create a GitHub Release** → EAS Build creates native app builds and optionally submits to stores
- **Manual trigger** → Use the "Run workflow" button in GitHub Actions for ad-hoc builds/updates
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0c4-fabb-71ec-b633-ea5952683abd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0c4-fabb-71ec-b633-ea5952683abd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

